### PR TITLE
DIAN-113

### DIFF
--- a/Arc/App/Models/ACTranslationKey.swift
+++ b/Arc/App/Models/ACTranslationKey.swift
@@ -71,6 +71,8 @@ public enum ACTranslationKey : String, TranslationKey {
     case login_resend_subheader
 
     case login_2FA_text
+    
+    case login_2FA_phone_text
 
     case login_2FA_morehelp_linked
 

--- a/Arc/App/Utilities/HMRestAPI/Models/AuthDetailsResponse.swift
+++ b/Arc/App/Utilities/HMRestAPI/Models/AuthDetailsResponse.swift
@@ -9,6 +9,7 @@
 import Foundation
 public enum AuthDetailType : String, Codable {
     case rater
+    case phone_number_entry
     case confirm_code
     case manual
 }

--- a/Arc/Components/Auth/Controllers/AuthHandler.swift
+++ b/Arc/Components/Auth/Controllers/AuthHandler.swift
@@ -120,24 +120,6 @@ public struct AuthHandler {
     }
     
     static public func verifyParticipant(id:String, didFinish:@escaping (ACResult<String>)->()){
-        
-        if (Arc.environment?.blockApiRequests ?? false) == true
-        {
-            didFinish(ACResult.success(id));
-            return;
-        }
-        let req = ConfirmationCode.Request(participant_id: id)
-        print(req.toString())
-        HMAPI.confirmationCode.execute(data: req, params: nil) { (urlResponse, hmResponse, fault) in
-            if hmResponse?.response?.success ?? false == true {
-                didFinish(ACResult.success(id))
-            } else {
-                var e:VerifyError = VerifyError.invalidId
-                if let r = urlResponse as? HTTPURLResponse, r.statusCode == 409 {
-                    e = VerifyError.enrolledId
-                }
-                didFinish(ACResult.error(e))
-            }
-        }
+        Arc.shared.authController.resend2FACode(id: id, didFinish: didFinish)
     }
 }

--- a/Arc/Components/Auth/ViewControllers/AC2FAuthenticationViewController.swift
+++ b/Arc/Components/Auth/ViewControllers/AC2FAuthenticationViewController.swift
@@ -213,24 +213,6 @@ public enum VerifyError : Error {
 //A small library containing two factor auth utilities
 public struct TwoFactorAuth {
 	static public func verifyParticipant(id:String, didFinish:@escaping (ACResult<String>)->()){
-		
-		if (Arc.environment?.blockApiRequests ?? false) == true
-		{
-			didFinish(ACResult.success(id));
-			return;
-		}
-		let req = ConfirmationCode.Request(participant_id: id)
-		print(req.toString())
-		confirmationCode.execute(data: req, params: nil) { (urlResponse, hmResponse, fault) in
-			if hmResponse?.response?.success ?? false == true {
-				didFinish(ACResult.success(id))
-			} else {
-                var e:VerifyError = VerifyError.invalidId
-                if let r = urlResponse as? HTTPURLResponse, r.statusCode == 409 {
-                    e = VerifyError.enrolledId
-                }
-				didFinish(ACResult.error(e))
-			}
-		}
+        Arc.shared.authController.resend2FACode(id: id, didFinish: didFinish)
 	}
 }


### PR DESCRIPTION
Added new auth flow that makes the user enter their phone number, instead of the server initiating the 2FA.  Sage bridge requires the user to enter the phone number themselves vs. getting it from another service on bridge using their ARC ID.  