### PR TITLE
DIAN-143

### DIFF
--- a/Arc/App/Models/ACTranslationKey.swift
+++ b/Arc/App/Models/ACTranslationKey.swift
@@ -1,976 +1,499 @@
 import Foundation
 public enum ACTranslationKey : String, TranslationKey {
     case country_key
-
     case language_key
-
     case app_name
-
     case key_native_language
-
     case notification_monthbefore
-
     case notification_weekbefore
-
     case notification_daybefore
-
     case notification1_firstday
-
     case notification1_default
-
     case notification1_halfway
-
     case notification1_lastday
-
     case notifications2_default
-
     case notification3_default
-
     case notification3_variation
-
     case notification4_default
-
     case notification4_lastday
-
     case notification_missedtests
-
     case notification_testproctor_header
-
     case notification_testproctor_body
-
     case dateshift_picker
-
     case dateshift_confirmation
-
     case language_prefer
-
     case gen_welcome_key
-
     case bysigning_key
-
     case privacy_linked
-
     case about_linked
-
-    case login_enter_raterid
-
-    case login_enter_arcid
-
-    case login_confirm_arcid
-
+    case login_enter_raterID
+    case login_enter_ARCID
+    case login_confirm_ARCID
     case login_problems_linked
-
     case login_enter_2FA
-
     case login_2FA_body
-
     case login_problems_2FA
-
     case login_resend_header
-
     case login_resend_subheader
-
     case login_2FA_text
-    
     case login_2FA_phone_text
-
     case login_2FA_morehelp_linked
-
     case onboarding_header
-
     case onboarding_body
-
     case radio_understand
-
     case radio_commit
-
     case radio_nocommit
-
     case onboarding_nocommit_header
-
     case onboarding_nocommit_body
-
     case onboarding_nocommit_landing_header
-
     case onboarding_nocommit_landing_body
-
     case onboarding_commit_header
-
     case onboarding_commit_body
-
     case onboarding_notifications_header1
-
     case onboarding_notifications_body1
-
     case onboarding_notifications_popup
-
     case onboarding_notifications_header2
-
     case onboarding_notifications_body2_ios
-
     case onboarding_notifications_body2_android
-
     case button_home_notifications
-
     case button_proceed_without_notifications
-
     case popup_opensettings
-
     case button_notnow
-
     case availability_header
-
     case availability_body
-
     case availability_start
-
     case availability_stop
-
     case availability_minimum_error
-
     case availability_maximum_error
-
     case availability_confirm
-
     case availability_change_linked
-
     case availability_change_confirm
-
     case availability_change_week
-
     case availability_change_week_confirm
-
     case idverify_header
-
     case idverify_body
-
     case idverify_undo
-
     case home_header1
-
     case home_header2
-
     case home_body2
-
     case home_header3
-
     case home_body3
-
     case home_header4
-
     case home_body4
-
     case home_header5
-
     case home_body5
-
     case home_header6
-
     case home_body6
-
     case home_header7
-
     case home_body7
-
     case resources_header
-
     case resources_availability
-
     case resources_contact
-
     case resources_about_link
-
     case resources_faq_link
-
     case resources_privacy_link
-
     case resources_nav_home
-
     case resources_nav_progress
-
     case resources_nav_earnings
-
     case resources_nav_resources
-
     case availability_changetime
-
     case availability_changedenied_test
-
     case availability_changedates
-
     case contact_call1
-
     case contact_call2
-
     case contact_email1
-
     case contact_email2
-
     case about_header
-
     case about_body
-
     case faq_header
-
     case faq_testing
-
     case faq_earnings
-
     case faq_technology
-
     case faq_subpage_subheader
-
     case faq_testing_header
-
     case faq_testing_q1
-
     case faq_testing_q2
-
     case faq_testing_q3
-
     case faq_testing_q4
-
     case faq_testing_q5
-
     case faq_testing_q6
-
     case faq_testing_q7
-
     case faq_testing_q8
-
     case faq_testing_q9
-
     case faq_testing_q10
-
     case faq_testing_a1
-
     case faq_testing_a2
-
     case faq_testing_a3
-
     case faq_testing_a4
-
     case faq_testing_a5
-
     case faq_testing_a6
-
     case faq_testing_a7
-
     case faq_testing_a8
-
     case faq_testing_a9
-
     case faq_testing_a10
-
     case faq_tech_header
-
     case faq_tech_q1
-
     case faq_tech_q2
-
     case faq_tech_q3
-
     case faq_tech_q4
-
     case faq_tech_q5
-
     case faq_tech_q6
-
     case faq_tech_q7
-
     case faq_tech_a1
-
     case faq_tech_a2
-
     case faq_tech_a3
-
     case faq_tech_a4
-
     case faq_tech_a5
-
     case faq_tech_a6
-
     case faq_tech_a7
-
     case faq_earnings_header
-
     case faq_earnings_q1
-
     case faq_earnings_q2
-
     case faq_earnings_q3
-
     case faq_earnings_q4
-
     case faq_earnings_q5
-
     case faq_earnings_a1
-
     case faq_earnings_a2
-
     case faq_earnings_a3
-
     case faq_earnings_a4
-
     case faq_earnings_a5
-
     case progress_daily_header
-
     case progress_dailystatus_complete
-
     case progress_dailystatus_remaining
-
     case progress_weekly_header
-
     case progess_weeklystatus
-
     case progress_startdate
-
     case progress_startdate_date
-
     case progress_enddate
-
     case progress_enddate_date
-
     case progress_study_header
-
     case progress_studystatus
-
     case progress_joindate
-
     case progress_joindate_date
-
     case progress_finishdate
-
     case progress_finishdate_date
-
     case progress_timebtwtesting
-
     case progress_timebtwtesting_unit
-
     case progress_studydisclaimer
-
     case progress_weekscompleted
-
     case progress_weeksremaining
-
     case progress_nextcycle
-
     case progress_cycledates
-
     case earnings_body0
-
     case earnings_body1
-
     case earnings_weektotal
-
     case earnings_studytotal
-
     case earnings_bonus_header
-
     case earnings_bonus_body
-
     case earnings_4of4_header
-
     case earnings_4of4_body
-
     case earnings_2aday_header
-
     case earnings_2aday_body
-
     case earnings_21tests_header
-
     case earnings_21tests_body
-
     case earnings_bonus_incomplete
-
     case earnings_bonus_complete
-
     case earnings_details_header
-
     case earnings_sync
-
     case earnings_sync_justnow
-
     case earnings_sync_datetime
-
     case earnings_details_subheader1
-
     case earnings_details_dates
-
     case earnings_details_complete_test_session
-
     case earnings_details_number_sessions
-
     case earnings_details_4of4
-
     case earnings_details_2aday
-
     case earnings_details_21sessions
-
     case earnings_details_currenttotal
-
     case earnings_details_subheader2
-
     case earnings_details_cycletotal
-
     case chronotype_header
-
     case chronotype_subheader
-
     case chronotype_body1
-
     case chronotype_q1
-
     case chronotype_q2
-
     case chronotype_body2
-
     case chronotype_workdays_sleep
-
     case chronotype_workdays_wake
-
     case chronotype_workfree_sleep
-
     case chronotype_workfree_wake
-
     case chronotype_disclaim1
-
     case chronotype_disclaim2
-
     case wakesurvey_header
-
     case wakesurvey_subheader
-
     case wakesurvey_body
-
     case wake_q1
-
     case wake_q2
-
     case wake_q3a
-
     case wake_q3b
-
     case wake_q4
-
     case wake_q5
-
     case wake_q6
-
     case wake_poor
-
     case wake_excellent
-
     case context_header
-
     case context_subheader
-
     case context_body
-
     case context_q1
-
     case context_q1_a1
-
     case context_q1_a2
-
     case context_q1_a3
-
     case context_q1_a4
-
     case context_q1_a5
-
     case context_q1_a6
-
     case context_q1_a7
-
     case context_q2
-
     case context_q2_a1
-
     case context_q2_a2
-
     case context_q2_a3
-
     case context_q2_a4
-
     case context_q2_a5
-
     case context_q2_a6
-
     case context_q2_a7
-
     case context_q3
-
     case context_bad
-
     case context_good
-
     case context_q4
-
     case context_tired
-
     case context_active
-
     case context_q5
-
     case context_q5_a1
-
     case context_q5_a2
-
     case context_q5_a3
-
     case context_q5_a4
-
     case context_q5_a5
-
     case context_q5_a6
-
     case context_q5_a7
-
     case context_q5_a8
-
     case context_q5_a9
-
     case context_q5_a10
-
     case testing_intro_header
-
     case testing_intro_body
-
     case testing_header_1
-
     case testing_header_2
-
     case testing_header_3
-
     case testing_tutorial_link
-
     case testing_tutorial_complete
-
     case testing_begin
-
     case testing_loading
-
     case testing_done
-
     case testing_interrupted_header
-
     case testing_interrupted_body
-
     case testing_id_header
-
     case testing_id_body
-
     case prices_header
-
     case prices_body
-
     case prices_body2
-
     case prices_isthisgood
-
     case prices_overlay
-
     case prices_whatwasprice
-
     case prices_complete
-
     case symbols_header
-
     case symbols_body
-
-    case grids_vb_body
-
-	case grids_overlay1
-
-    case grids_tutorial_vb_step1
-
-	case grids_overlay2
-
     case symbols_match
-
     case symbols_or
-
     case symbols_complete
-
     case grids_header
-
     case grids_body
-
+    case grids_overlay1
+    case grids_overlay2
     case grids_subheader_fs
-
     case grids_overlay3
-
     case grids_overlay3_pt2
-
     case grids_subheader_boxes
-
     case grids_complete
-
+    case grids_vb_body
+    case grids_tutorial_vb_step1
+    case grids_tutorial_vb_place
+    case grids_tutorial_vb_place_other
+    case grids_tutorial_vb_change_mind
+    case grids_tutorial_vb_mech1
+    case grids_tutorial_vb_mech2
+    case grids_tutorial_vb_mech3
+    case grids_tutorial_vb_mech4
+    case grids_tutorial_vb_remove
+    case grids_tutorial_vb_select
+    case grids_tutorial_vb_tap_locations
     case progress_schedule_header
-
     case progress_baseline_notice
-
     case progress_practice_body1
-
     case progress_practice_body2
-
     case progress_schedule_body1
-
     case progress_schedule_body2
-
     case progress_schedule_status1
-
     case progress_schedule_status2
-
     case progress_earnings_header
-
     case progress_earnings_body1
-
     case progress_earnings_body2
-
     case progress_earnings_status1
-
     case progress_earnings_status2
-
     case progress_earnings_status3
-
     case progress_earnings_status4
-
     case progress_goal_header
-
     case progress_cyclecomplete_header
-
     case progress_cycleorstudycomplete_body
-
     case overlay_nextcycle
-
     case progress_studycomplete_header
-
     case progress_studytotals_header
-
     case progress_studytotals_body
-
     case progress_studytotals_earned
-
     case progress_studytotals_tests
-
     case progress_studytotals_days
-
     case progress_studytotals_goals
-
     case progress_endoftest_syncing
-
     case progress_endoftest_nosync
-
     case login_error1
-
+    case login_error1_link
     case login_error2
-
     case login_error3
-
     case login_error4
-
     case button_help
-
     case button_begin
-
     case button_back
-
     case button_sendnewcode
-
     case button_submittime
-
     case button_next
-
     case button_call
-
     case button_email
-
     case button_done
-
     case button_change
-
     case button_submit
-
     case button_submitdates
-
-    case button_finish_tutorial
-    
-	case button_settings
-
-    case button_showme
-    
-	case button_close
-
     case button_signin
-
     case button_beginsurvey
-
     case button_begintest
-
     case button_okay
-
     case button_viewfaq
-
     case button_viewdetails
-
     case button_chooseanswer
-
+    case button_settings
+    case button_close
     case button_confirm
-
     case button_adjustschedule
-
-	case popup_done
-    
-    case popup_tutorial_change
-    
-    case popup_tutorial_perfect
-    
-	case popup_tutorial_view
-
+    case button_showme
+    case button_finishtutorial
     case button_returntohome
-
+    case button_choosetime
     case popup_scroll
-
     case popup_showmore
-
     case popup_begin
-
     case popup_drag
-
     case popup_gotit
-
     case popup_next
-
+    case popup_done
+    case popup_tutorial_view
     case popup_tutorial_welcome
-
     case popup_tutorial_quit
-
     case popup_tutorial_price_intro
-
     case popup_tutorial_price_memorize
-
     case prices_tutorial_item1
-
     case prices_tutorial_price1
-
     case prices_tutorial_price1_match
-
-    case popup_tutorial_mechanics
-    
-	case popup_tutorial_greatchoice1
-
     case prices_tutorial_item2
-
     case prices_tutorial_price2
-
-    case popup_tutorial_great_remove
-    
-	case popup_tutorial_recall
-
-    case popup_tutorial_remove
-    
-	case popup_tutorial_choose2
-
     case prices_tutorial_price2_match
-
     case prices_tutorial_item3
-
     case prices_tutorial_price3
-
     case prices_tutorial_price3_match
-
     case popup_tutorial_choose1
-
+    case popup_tutorial_greatchoice1
     case popup_tutorial_greatchoice2
-
+    case popup_tutorial_recall
+    case popup_tutorial_choose2
     case popup_tutorial_complete
-
     case popup_tutorial_tile
-
     case popup_tutorial_tilestop
-
     case popup_tutorial_tilesbottom
-
     case popup_tutorial_middle_instructions
-
     case popup_tutorial_tiletap
-
     case popup_tutorial_pricetap
-
     case popup_tutorial_greatjob
-
     case popup_tutorial_nice
-
     case popup_tutorial_grid_recall
-
     case popup_tutorial_rememberbox
-
-    case popup_tutorial_cellbox
-    
-	case popup_tutorial_tapbox
     case popup_tutorial_ready
-
     case popup_tutorial_part2
-
     case popup_tutorial_tapf1
-
-    case popup_tutorial_tapbox4
-    
-    case popup_tutorial_tapsymbol
-    
-    case popup_tutorial_tapsymbol2
-    
-    case popup_tutorial_tapsymbol3
-    
-	case popup_tutorial_needhelp
-
-	case popup_tutorial_remindme
-    
-    case popup_tutorial_subheader
-
     case popup_tutorial_tapf2
-
     case popup_tutorial_tapf3
-
+    case popup_tutorial_tapsymbol
+    case popup_tutorial_tapsymbol2
     case popup_tutorial_selectbox
-
+    case popup_tutorial_selectboxV2
     case popup_tutorial_boxhint
-
+    case popup_tutorial_tapbox
     case popup_tutorial_tapbox2
-
     case popup_tutorial_tapbox3
-
+    case popup_tutorial_tapbox4
+    case popup_tutorial_needhelp
+    case popup_tutorial_remindme
+    case popup_tutorial_perfect
+    case popup_tutorial_subheader
+    case popup_tutorial_cellbox
     case popup_tour
-
     case popup_tab_home
-
     case popup_tab_progress
-
     case popup_tab_earnings
-
     case popup_tab_resources
-
     case popup_nicejob
-
     case low_memory_toast
-
     case low_memory_restart_dialogue_header
-
     case low_memory_restart_dialogue
-
     case day_abbrev_sun
-
     case day_abbrev_mon
-
     case day_abbrev_tues
-
     case day_abbrev_weds
-
     case day_abbrev_thurs
-
     case day_abbrev_fri
-
     case day_abbrev_sat
-
     case status_ongoing
-
     case status_inprogress
-
     case status_done
-
     case status_done_withdate
-
     case status_nonedone
-
     case radio_yes
-
     case radio_no
-
     case radio_0
-
     case radio_1
-
     case radio_2
-
     case radio_3
-
     case radio_4
-
     case radio_5
-
     case radio_6
-
     case radio_7
-
     case list_selectone
-
     case list_selectall
-
     case month_january
-
     case month_febuary
-
     case month_march
-
     case month_april
-
     case month_may
-
     case month_june
-
     case month_july
-
     case month_august
-
     case month_september
-
     case month_october
-
     case month_november
-
     case month_december
-
     case footnote_symbol
-
     case earnings_symbol
-
     case time_format
-
     case format_date
-
     case money_prefix
-
     case money_suffix
-
     case prices_test_prefix
-
     case prices_test_suffix
-
     case unit_months
-
     case battery_optimization_header
-
     case battery_optimization_overview
-
     case battery_optimization_prompt
-
     case battery_optimization_reminder
-
-    case legacy_migration_header
-
-    case legacy_migration_body
-
-    case legacy_migration_body2
-
-    case legacy_migration_progress
-
-    case legacy_migration_error
-
-    case legacy_migration_contact
-
     case button_install_update
+    case legacy_migration_header
+    case legacy_migration_body
+    case legacy_migration_body2
+    case legacy_migration_progress
+    case legacy_migration_error
+    case legacy_migration_contact
 
 }

--- a/Arc/App/Utilities/HMRestAPI/Models/StatusCode.swift
+++ b/Arc/App/Utilities/HMRestAPI/Models/StatusCode.swift
@@ -53,7 +53,7 @@ public enum StatusCode  {
     /// - returns: A string from the translation document for the current language
     var failureMessage:String? {
         if let code = code {
-            if code == 401 {
+            if code == 401 || code == 406 {
                 return "Invalid Rater ID or ARC ID".localized(ACTranslationKey.login_error1)
             }
             if code == 409 {

--- a/Arc/Components/Auth/ViewControllers/ACAuthViewController.swift
+++ b/Arc/Components/Auth/ViewControllers/ACAuthViewController.swift
@@ -102,7 +102,7 @@ open class ACAuthViewController: BasicSurveyViewController {
 			if questionId == "auth_2"{
 				if value != self?.initialValue {
 					
-					self?.set(error:"Subject ID doesn’t match")
+					self?.set(error:"Non-matching ARC ID".localized(ACTranslationKey.login_error4))
 					didFinish(false)
 					return
 					
@@ -111,7 +111,7 @@ open class ACAuthViewController: BasicSurveyViewController {
 			if questionId == "auth_arc_id_confirm_no_rater"{
 				if value != self?.initialValue {
 					
-					self?.set(error:"Subject ID doesn’t match")
+                    self?.set(error:"Non-matching ARC ID".localized(ACTranslationKey.login_error4))
 					didFinish(false)
 					return
 					
@@ -150,7 +150,7 @@ open class ACAuthViewController: BasicSurveyViewController {
 
 			if initialValue != controller.getUserName() {
 				
-				self.set(error: "Subject ID does not match.")
+				self.set(error: "Non-matching ARC ID".localized(ACTranslationKey.login_error4))
 
 			} else {
 				let top:CustomViewController<InfoView>? = getTopViewController()

--- a/Arc/Components/Auth/ViewControllers/ACResponsiveAuthViewController.swift
+++ b/Arc/Components/Auth/ViewControllers/ACResponsiveAuthViewController.swift
@@ -112,7 +112,7 @@ open class ACResponsiveAuthViewController: BasicSurveyViewController {
             if questionId == "auth_confirm" {
                 if value != self?.initialValue {
 
-                    self?.set(error:"Subject ID doesn’t match")
+                    self?.set(error:"Non-matching ARC ID".localized(ACTranslationKey.login_error4))
                     didFinish(false)
                     return
 
@@ -173,7 +173,7 @@ open class ACResponsiveAuthViewController: BasicSurveyViewController {
             }
             if initialValue != controller.getUserName() {
 
-                self.set(error: "Subject ID does not match.")
+                self.set(error: "Non-matching ARC ID".localized(ACTranslationKey.login_error4))
 
             } else {
                 

--- a/Arc/Components/Auth/ViewControllers/WelcomeViewController.xib
+++ b/Arc/Components/Auth/ViewControllers/WelcomeViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -33,26 +33,32 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="2K2-uK-FSQ">
-                    <rect key="frame" x="143.5" y="518" width="88" height="30"/>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="2K2-uK-FSQ">
+                    <rect key="frame" x="73" y="518" width="229" height="30"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OfG-Rv-UYw" customClass="HMMarkupButton" customModule="HMMarkup">
-                            <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OfG-Rv-UYw" customClass="HMMarkupButton" customModule="HMMarkup">
+                            <rect key="frame" x="0.0" y="0.0" width="106" height="30"/>
                             <accessibility key="accessibilityConfiguration" identifier="about_button"/>
                             <state key="normal" title="About This App"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="about_linked"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
+                                    <integer key="value" value="2"/>
+                                </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="aboutPressed:" destination="-1" eventType="touchUpInside" id="tML-0u-NkZ"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="evM-Qz-X7r" customClass="HMMarkupButton" customModule="HMMarkup">
-                            <rect key="frame" x="58" y="0.0" width="30" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="evM-Qz-X7r" customClass="HMMarkupButton" customModule="HMMarkup">
+                            <rect key="frame" x="134" y="0.0" width="95" height="30"/>
                             <accessibility key="accessibilityConfiguration" identifier="privacy_button"/>
                             <state key="normal" title="Privacy Policy"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="privacy_linked"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
+                                    <integer key="value" value="2"/>
+                                </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="privacyPressed:" destination="-1" eventType="touchUpInside" id="g0D-Hu-Ndu"/>
@@ -113,13 +119,14 @@
                     </subviews>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="0KY-bW-aN9" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="32" id="4aS-u2-bkW"/>
                 <constraint firstItem="Ae7-Xv-MhH" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="5xv-Qr-QsR"/>
-                <constraint firstItem="2K2-uK-FSQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="7yV-tR-1Dr"/>
+                <constraint firstItem="2K2-uK-FSQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="7yV-tR-1Dr"/>
                 <constraint firstItem="2K2-uK-FSQ" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="AJd-xR-RcA"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2K2-uK-FSQ" secondAttribute="trailing" constant="20" id="DSr-SN-Ye8"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2K2-uK-FSQ" secondAttribute="trailing" constant="16" id="DSr-SN-Ye8"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0KY-bW-aN9" secondAttribute="trailing" constant="32" id="Jd7-KB-Q31"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="NAL-fM-4x4" secondAttribute="trailing" constant="20" id="JdM-xT-eP1"/>
                 <constraint firstItem="NAL-fM-4x4" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Zvc-79-KMx"/>
@@ -129,10 +136,21 @@
                 <constraint firstItem="NAL-fM-4x4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="y3U-zo-O5m"/>
                 <constraint firstItem="0KY-bW-aN9" firstAttribute="top" secondItem="2K2-uK-FSQ" secondAttribute="bottom" constant="25" id="yBD-lV-xg3"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="53.600000000000001" y="48.125937031484263"/>
         </view>
     </objects>
+    <designables>
+        <designable name="0KY-bW-aN9">
+            <size key="intrinsicContentSize" width="64" height="34"/>
+        </designable>
+        <designable name="Of1-wh-Mk4"/>
+        <designable name="OfG-Rv-UYw">
+            <size key="intrinsicContentSize" width="106" height="30"/>
+        </designable>
+        <designable name="evM-Qz-X7r">
+            <size key="intrinsicContentSize" width="95" height="30"/>
+        </designable>
+    </designables>
     <resources>
         <namedColor name="Primary">
             <color red="0.0" green="0.3411764705882353" blue="0.50588235294117645" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -141,7 +159,7 @@
             <color red="0.0" green="0.49000000953674316" blue="0.68000000715255737" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Primary Text">
-            <color red="0.23499999940395355" green="0.23499999940395355" blue="0.23499999940395355" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23921568627450981" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Secondary Text">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Arc/Components/Home/ACHomeView.swift
+++ b/Arc/Components/Home/ACHomeView.swift
@@ -175,23 +175,35 @@ public class ACHomeView: ACTemplateView {
             $0.setTitleColor(UIColor(named: "Primary"), for: .normal)
             
             $0.addAction {
-				let message = "We’ll now open your Settings App. Once there, tap Notifications, and turn on the Allow Notifications Switch.".localized("popup_opensettings")
-				Arc.shared.displayAlert(message: message,
-					options: [.default("OK".localized(ACTranslationKey.button_okay), {
-						guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
-							return
-						}
-						
-						if UIApplication.shared.canOpenURL(settingsUrl) {
-							UIApplication.shared.open(settingsUrl, completionHandler: { (success) in
-								print("Settings opened: \(success)") // Prints true
-							})
-						}
-					}),
-							  
-							  .cancel("Not Now".localized("button_notnow"), {})
-					]
-				)
+                
+                Arc.shared.notificationController.authenticateNotifications { (granted, error) in
+                    
+                    DispatchQueue.main.async {
+                        
+                        if granted == true
+                        {
+                            return
+                        }
+                        
+                        let message = "We’ll now open your Settings App. Once there, tap Notifications, and turn on the Allow Notifications Switch.".localized("popup_opensettings")
+                        Arc.shared.displayAlert(message: message,
+                            options: [.default("OK".localized(ACTranslationKey.button_okay), {
+                                guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                                    return
+                                }
+                                
+                                if UIApplication.shared.canOpenURL(settingsUrl) {
+                                    UIApplication.shared.open(settingsUrl, completionHandler: { (success) in
+                                        print("Settings opened: \(success)") // Prints true
+                                    })
+                                }
+                            }),
+                                      
+                                      .cancel("Not Now".localized("button_notnow"), {})
+                            ]
+                        )
+                    }
+                }
             }
         }
 		

--- a/Arc/Components/Progress/views/ACEarningsDetailView.swift
+++ b/Arc/Components/Progress/views/ACEarningsDetailView.swift
@@ -49,6 +49,8 @@ public class ACEarningsDetailView : ACTemplateView {
 		 view.stack { [unowned self] in
 			$0.axis = .vertical
 			$0.spacing = 20
+            $0.trailingAnchor.constraint(equalTo: view.superview!.trailingAnchor).isActive = true
+            $0.widthAnchor.constraint(equalTo: view.superview!.widthAnchor, multiplier: 1).isActive = true
 //			$0.stack {
 //				$0.axis = .vertical
 //                

--- a/Arc/Components/Scheduler/ViewControllers/StartDateShiftViewController.swift
+++ b/Arc/Components/Scheduler/ViewControllers/StartDateShiftViewController.swift
@@ -155,7 +155,8 @@ open class StartDateShiftViewController: BasicSurveyViewController {
                 Arc.shared.notificationController.clear(sessionNotifications: id)
                 Arc.shared.notificationController.schedule(upcomingSessionNotificationsWithLimit: 32)
                 _ = Arc.shared.notificationController.scheduleDateConfirmationsForUpcomingStudy(force: true)
-
+                let studies = Arc.shared.studyController.getAllStudyPeriods().sorted(by: {$0.studyID < $1.studyID})
+                Arc.shared.sessionController.uploadSchedule(studyPeriods: studies)
                 Arc.shared.scheduleController.upload(confirmedSchedule: id);
 
                 Arc.shared.studyController.save()

--- a/Arc/Components/Survey/ViewControllers/BasicSurveyViewController.swift
+++ b/Arc/Components/Survey/ViewControllers/BasicSurveyViewController.swift
@@ -575,7 +575,7 @@ open class BasicSurveyViewController: UINavigationController, SurveyInputDelegat
     open override func popToRootViewController(animated: Bool) -> [UIViewController]? {
         let vcs = super.popToRootViewController(animated: animated);
         
-        currentIndex = viewControllers.count - 1
+        currentIndex = 0
         print("Controller index:", currentIndex)
 		set(error: nil)
 

--- a/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestTutorialViewController.swift
+++ b/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestTutorialViewController.swift
@@ -428,7 +428,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
             weakSelf.currentHint = weakSelf.view.window?.hint {
                 $0.content = """
                 In part three, place each item in its location from part one.
-                """.localized(ACTranslationKey.popup_tutorial_selectbox)
+                """.localized(ACTranslationKey.popup_tutorial_selectboxV2)
                 $0.buttonTitle = "I'm Ready".localized(ACTranslationKey.popup_tutorial_ready)
                 $0.onTap = {
                     weakSelf.test.collectionView.isUserInteractionEnabled = true
@@ -556,7 +556,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
             weakSelf.currentHint = weakSelf.view.window?.hint {
                 $0.content = """
                     *Nice work!*\nIt looks like you didn't need any help with placement, but we want to make sure we still teach you how to swap and remove items before you move onto the actual test.
-                    """.localized(ACTranslationKey.popup_tutorial_mechanics)
+                    """.localized(ACTranslationKey.grids_tutorial_vb_mech1)
                 $0.buttonTitle = "Show Me".localized(ACTranslationKey.button_showme)
                 $0.onTap = {
                     weakSelf.phase = .mechanics
@@ -591,7 +591,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                weakSelf.currentHint = weakSelf.view.window?.hint {
                    $0.content = """
                        If you change your mind after placing an item, you can move it. Let's try it.
-                       """.localized(ACTranslationKey.popup_tutorial_change)
+                       """.localized(ACTranslationKey.grids_tutorial_vb_mech2)
                        
                    $0.updateHintContainerMargins()
                    $0.updateTitleStackMargins()
@@ -688,7 +688,6 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                    $0.layout {
                        $0.centerX == weakSelf.view.centerXAnchor
                        $0.width == 252
-                       $0.height == 100
                        if index.row/5 > 2 {
                            //If above
                            $0.bottom == weakSelf.gridChoice!.topAnchor + 20
@@ -722,7 +721,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                weakSelf.currentHint = weakSelf.view.window?.hint {
                    $0.content = """
                        Great! If you would like to clear a box with an item, first tap that box...
-                       """.localized(ACTranslationKey.popup_tutorial_great_remove)
+                       """.localized(ACTranslationKey.grids_tutorial_vb_mech3)
                    $0.targetView = cell
                    $0.configure(with: IndicatorView.Config(
                        primaryColor: UIColor(named:"HintFill")!,
@@ -737,7 +736,6 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                    $0.layout {
                        $0.centerX == weakSelf.view.centerXAnchor
                        $0.width == 252
-                       $0.height == 134
                        if index.row/5 > 2 {
                            //If above
                            $0.bottom == cell.topAnchor + 40
@@ -771,7 +769,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                weakSelf.currentHint = weakSelf.view.window?.hint {
                    $0.content = """
                        ...then tap *Remove Item*.
-                       """.localized(ACTranslationKey.popup_tutorial_remove)
+                       """.localized(ACTranslationKey.grids_tutorial_vb_mech4)
                     $0.targetView = removeButton
                     removeButton?.addAction {
                        //weakSelf.tutorialAnimation.time = 26
@@ -821,7 +819,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
                        arrowAbove: false))
                    $0.updateHintContainerMargins()
                    $0.updateTitleStackMargins()
-                   $0.buttonTitle = "Finish Tutorial".localized(ACTranslationKey.button_finish_tutorial)
+                   $0.buttonTitle = "Finish Tutorial".localized(ACTranslationKey.button_finishtutorial)
                    $0.onTap = {
                        weakSelf.removeFinalHint()
                        weakSelf.finishTutorial()
@@ -845,7 +843,8 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
 				return
 			}
             weakSelf.tutorialAnimation.pause()
-            weakSelf.maybeRemoveSelectNextTwoHint()
+            weakSelf.currentHint?.removeFromSuperview()
+            weakSelf.currentHint = nil
             //Otherwise let's give them a choice.
             weakSelf.currentHint = weakSelf.view.window?.hint {
                 $0.content  = "Need Help?".localized(ACTranslationKey.popup_tutorial_needhelp)
@@ -898,8 +897,10 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
             weakSelf.symbolSelected = true
 
             weakSelf.tutorialAnimation.pause()
+            weakSelf.currentHint?.removeFromSuperview()
+            weakSelf.currentHint = nil
             weakSelf.currentHint = weakSelf.view.window?.hint {
-                $0.content = "Change your mind? Select a different item to replace, or tap *Remove Item* to clear."
+                $0.content = "Change your mind? Select a different item to replace, or tap *Remove Item* to clear.".localized(ACTranslationKey.grids_tutorial_vb_change_mind)
                 $0.buttonTitle = "Got It".localized(ACTranslationKey.popup_gotit)
                 $0.onTap = {[weak self] in
                     self?.removeFinalHint()
@@ -981,7 +982,8 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
             }
 
             cell.backgroundColor = UIColor(named: "Secondary")
-
+            weakSelf.currentHint?.removeFromSuperview()
+            weakSelf.currentHint = nil
             weakSelf.currentHint = weakSelf.view.window?.hint {
                 $0.content = """
                 *Hint:* The cell phone was located here. Tap this box.
@@ -1043,7 +1045,7 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
         self.currentHint = self.view.window?.hint {
             $0.content = """
             Great! Now, place the other two items on the grid.
-            """.localized(ACTranslationKey.popup_tutorial_tapbox)
+            """.localized(ACTranslationKey.grids_tutorial_vb_place_other)
             $0.configure(with: IndicatorView.Config(
             primaryColor: UIColor(named:"HintFill")!,
             secondaryColor: UIColor(named:"HintFill")!,
@@ -1063,15 +1065,6 @@ class ExtendedGridTestTutorialViewController: ACTutorialViewController, Extended
         }
     }
 
-    func maybeRemoveSelectNextTwoHint() {
-        guard let hint = self.currentHint else { return }
-        if hint.content == "".localized(ACTranslationKey.popup_tutorial_tapbox) {
-            self.currentHint?.removeFromSuperview()
-            self.currentHint = nil
-            showingSelectNextTwo = false
-            self.removeHint(hint: "hint")
-        }
-    }
 
     func removeFinalHint() {
         self.currentHint?.removeFromSuperview()

--- a/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestViewController.swift
+++ b/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestViewController.swift
@@ -303,7 +303,7 @@ open class ExtendedGridTestViewController: ArcViewController, UICollectionViewDe
         if isPracticeTest {
 			tapOnTheFsLabel.text = "Tap the boxes where the items were located in part one.".localized(ACTranslationKey.popup_tutorial_subheader)
         } else {
-            tapOnTheFsLabel.text = "Tap on the location of each item.".localized(ACTranslationKey.grids_subheader_boxes)
+            tapOnTheFsLabel.text = "Tap on the locations of the items.".localized(ACTranslationKey.grids_tutorial_vb_tap_locations)
             collectionView.leadingAnchor.constraint(equalTo:self.view.leadingAnchor, constant: 4).isActive = true
             self.view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor, constant: 4).isActive = true
         }

--- a/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestViewController.xib
+++ b/Arc/Components/TestManager/ViewControllers/Grid Test/ExtendedGridTestViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -92,7 +92,7 @@
                                 <constraint firstAttribute="width" priority="999" constant="256" id="6Jk-b2-iAn"/>
                             </constraints>
                             <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="18"/>
-                            <state key="normal" title="CONTINUE">
+                            <state key="normal" title="NEXT">
                                 <color key="titleColor" name="Secondary Text"/>
                             </state>
                             <userDefinedRuntimeAttributes>
@@ -105,6 +105,7 @@
                                 <userDefinedRuntimeAttribute type="number" keyPath="numberOfLines">
                                     <integer key="value" value="0"/>
                                 </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="button_next"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="continuePressed:" destination="-1" eventType="touchUpInside" id="dQ1-NX-fLk"/>
@@ -126,10 +127,10 @@
     </objects>
     <designables>
         <designable name="11X-8i-GZq">
-            <size key="intrinsicContentSize" width="110.5" height="20"/>
+            <size key="intrinsicContentSize" width="108.5" height="20"/>
         </designable>
         <designable name="m8K-FL-SjN">
-            <size key="intrinsicContentSize" width="92" height="33"/>
+            <size key="intrinsicContentSize" width="46" height="34"/>
         </designable>
     </designables>
     <resources>

--- a/Arc/Components/TestManager/Views/GridTestSelectionView.xib
+++ b/Arc/Components/TestManager/Views/GridTestSelectionView.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,12 +17,15 @@
                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="cXF-kP-nB7">
                     <rect key="frame" x="0.0" y="4" width="264" height="204"/>
                     <subviews>
-                        <label autoresizesSubviews="NO" opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="752" insetsLayoutMarginsFromSafeArea="NO" text="Select the item that was here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iJ4-HL-WOF">
-                            <rect key="frame" x="20.5" y="16" width="223" height="20.5"/>
+                        <label autoresizesSubviews="NO" opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="752" insetsLayoutMarginsFromSafeArea="NO" text="Select the item that was here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iJ4-HL-WOF" customClass="ACLabel" customModule="ArcUIKit">
+                            <rect key="frame" x="21.5" y="16" width="221.5" height="20.5"/>
                             <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                             <size key="shadowOffset" width="0.0" height="0.0"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="grids_tutorial_vb_select"/>
+                            </userDefinedRuntimeAttributes>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="lIh-r4-H0g">
                             <rect key="frame" x="26" y="46.5" width="212" height="80"/>
@@ -38,7 +43,7 @@
                                             <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                                         </button>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstItem="VGu-gJ-f3Y" firstAttribute="top" secondItem="igU-lv-Mxe" secondAttribute="top" id="5Fw-Cx-2Ne"/>
                                         <constraint firstAttribute="height" constant="80" id="7q4-Vc-EzL"/>
@@ -65,7 +70,7 @@
                                             <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                                         </button>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstItem="SNB-Cx-t2Y" firstAttribute="leading" secondItem="IW8-eP-vfG" secondAttribute="leading" id="8xc-Tg-bEI"/>
                                         <constraint firstAttribute="bottom" secondItem="SNB-Cx-t2Y" secondAttribute="bottom" id="QDT-vi-bzZ"/>
@@ -92,7 +97,7 @@
                                             <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                                         </button>
                                     </subviews>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstItem="JpM-gx-z4a" firstAttribute="top" secondItem="mp1-0k-Ett" secondAttribute="top" id="FX7-Bs-4ey"/>
                                         <constraint firstItem="amU-VG-ZbM" firstAttribute="top" secondItem="mp1-0k-Ett" secondAttribute="top" id="HDc-S2-BkE"/>
@@ -116,12 +121,31 @@
                                 <constraint firstAttribute="width" priority="999" constant="264" id="xEv-Gh-vzY"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2ri-NR-mt0">
+                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2ri-NR-mt0" customClass="ACButton" customModule="ArcUIKit">
                             <rect key="frame" x="81.5" y="147.5" width="101" height="38.5"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                            <color key="tintColor" name="Badge Gray"/>
                             <state key="normal" title="Remove Item">
                                 <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </state>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="0.0"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="string" keyPath="translationKey" value="grids_tutorial_vb_remove"/>
+                                <userDefinedRuntimeAttribute type="color" keyPath="primaryColor">
+                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="secondaryColor">
+                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="topColor">
+                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </userDefinedRuntimeAttribute>
+                                <userDefinedRuntimeAttribute type="color" keyPath="bottomColor">
+                                    <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
                         </button>
                     </subviews>
                     <edgeInsets key="layoutMargins" top="16" left="0.0" bottom="18" right="0.0"/>
@@ -157,5 +181,11 @@
         <image name="key" width="60.5" height="105.5"/>
         <image name="pen" width="60.5" height="105.5"/>
         <image name="phone" width="60.5" height="105.5"/>
+        <namedColor name="Badge Gray">
+            <color red="0.70196078431372544" green="0.70196078431372544" blue="0.70196078431372544" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
Pull in HappyMedium's code changes to the ARC Core library

…TRLab-WashU/HM_iOS_ARC_Core into Arc2.0_development

* 'HappyMedium_Arc2.0_development' of https://github.com/CTRLab-WashU/HM_iOS_ARC_Core:
  EXR-1150, make sure grids_tutorial_vb_mech3 shows all text in Spanish.
  EXR-1148 Fixed more case-related translation key issues
  EXR-1147 fixed case issue with ACTranslationKey (popup_tutorial_selectboxV2 vs popup_tutorial_selectboxv2)
  Accidentally added two of the same translation key.
  EXR-1145 make sure the "problems logging in" button appears for any login error. Updated translations doc with consistent casing.
  EXR-1126: Fixed missing translation for subject id mismatch error.
  Changed 'Continue' button to 'Next' (we have no translations for 'Continue')
  EXR-1125 Grids tutorial must make sure to clear any existing hints before adding a new one
  EXR-1125 - Updating translations for grids version B
  HASD-793 Changing the start date of upcoming test cycle needs to upload a new test schedule as well.
  popToRootViewController was setting currentIndex to the wrong value (this was causing a crash whenever users would click "Change Times" during setup)
  EXR-1117/HASD-789 -- Fixed issue with Earnings Details page not laying out properly in some circumstances.
  HASD-783 "Turn On Notifications" button now calls authenticateNotifications to ensure that the application has requested notification permissions.
  Revert "Revert "HASD-782 total and weekly earnings switched""

# Conflicts:
#	Arc/App/Models/ACTranslationKey.swift