### PR TITLE
Dian 76

### DIFF
--- a/Arc/Components/Onboarding/NotificationsRejectedViewController.swift
+++ b/Arc/Components/Onboarding/NotificationsRejectedViewController.swift
@@ -65,7 +65,8 @@ public class NotificationsRejectedViewController : CustomViewController<InfoView
 		customView.backgroundColor = UIColor(named:"Primary")!
 		customView.setTextColor(UIColor(named: "Secondary Text"))
         
-		
+        // Record that we've shown the notifications rejected screen, fix related to DIAN-76
+        UserDefaults.standard.setValue(true, forKey: "rejectedFirstNotifications")
 		
 		customView.setButtonColor(style:.secondary)
 		
@@ -121,6 +122,10 @@ public class NotificationsRejectedViewController : CustomViewController<InfoView
 		Roboto.PostProcess.link(button1)
 		
 		button1.addAction {  [weak self] in
+            // We are proceeding without fixing notifications. Make sure we record that we've continued past notifications so that
+            // when the app opens in the future we don't bug them about it again (DIAN-76).
+            UserDefaults.standard.setValue(true, forKey: "passedNotificationsPrompting")
+            
 			self?.surveyInputDelegate?.tryNextPressed()
 		}
 		customView.setAdditionalFooterContent(button1)

--- a/Arc/Components/Onboarding/OnboardingSurveyViewController.swift
+++ b/Arc/Components/Onboarding/OnboardingSurveyViewController.swift
@@ -21,10 +21,20 @@ open class OnboardingSurveyViewController: BasicSurveyViewController {
 	}
 	
 	open override func customViewController(forQuestion question: Survey.Question) -> UIViewController? {
-		if question.state == "NotificationAccess" {
-			currentViewControllerAlwaysHidesBarButtons = true
-
-			return NotificationPermissionViewController()
+        // See if we've already rejected the first notifications previously, related to DIAN-76
+        let alreadyRejectedFirstNotifications = UserDefaults.standard.bool(forKey: "rejectedFirstNotifications")
+		
+        if question.state == "NotificationAccess" {
+            if alreadyRejectedFirstNotifications {
+                // we've already rejected previously, so go to the screen to convince them it's a bad
+                // idea instead of the first screen (which will cause an infinite loop)
+                currentViewControllerAlwaysHidesBarButtons = true
+                return NotificationsRejectedViewController()
+            } else {
+                // Things are normal, proceed to the first notifications controller
+                currentViewControllerAlwaysHidesBarButtons = true
+                return NotificationPermissionViewController()
+            }
 		}
 		if question.state == "NotificationAccessRejected" {
 			currentViewControllerAlwaysHidesBarButtons = true


### PR DESCRIPTION
Core changes related to fixing DIAN 76. Basically we need to do two things:

1) Record when we've seen the notification request rejected screen previously, so we go directly there in the case of an app restart that still takes us to onboarding.
2) If we "continue anyway" from notifications rejected, record that fact so we skip this part of onboarding in the future