### PR TITLE
DIAN-168 

### DIFF
--- a/Arc.xcodeproj/project.pbxproj
+++ b/Arc.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		C5F77F37222F095200BECAE1 /* SignatureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F77F36222F095200BECAE1 /* SignatureViewController.swift */; };
 		C5FDC5B4258BE4A100E80E69 /* AuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FDC5B3258BE4A100E80E69 /* AuthHandler.swift */; };
 		CB32BCEF2717C82D00B05501 /* JsonModel in Frameworks */ = {isa = PBXBuildFile; productRef = CB32BCEE2717C82D00B05501 /* JsonModel */; };
+		CB5C294E2732EEC400CEC823 /* SageAuthController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5C294D2732EEC400CEC823 /* SageAuthController.swift */; };
 		CB855AC627178C60004599EC /* BridgeApp in Frameworks */ = {isa = PBXBuildFile; productRef = CB855AC527178C60004599EC /* BridgeApp */; };
 		CB855AC827178C60004599EC /* BridgeAppUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB855AC727178C60004599EC /* BridgeAppUI */; };
 		CB855AD027178D32004599EC /* SageEarningsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB855ACA27178D31004599EC /* SageEarningsController.swift */; };
@@ -601,6 +602,7 @@
 		C5F77F38222F15DD00BECAE1 /* SignatureView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignatureView.xib; sourceTree = "<group>"; };
 		C5F77F3A22306CFA00BECAE1 /* DateRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeView.swift; sourceTree = "<group>"; };
 		C5FDC5B3258BE4A100E80E69 /* AuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHandler.swift; sourceTree = "<group>"; };
+		CB5C294D2732EEC400CEC823 /* SageAuthController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SageAuthController.swift; path = Arc/Sage/SageAuthController.swift; sourceTree = SOURCE_ROOT; };
 		CB855ACA27178D31004599EC /* SageEarningsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SageEarningsController.swift; sourceTree = "<group>"; };
 		CB855ACB27178D31004599EC /* SageScheduleController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SageScheduleController.swift; sourceTree = "<group>"; };
 		CB855ACC27178D31004599EC /* CompletedTestsDefaultsReport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompletedTestsDefaultsReport.swift; sourceTree = "<group>"; };
@@ -1395,6 +1397,7 @@
 			children = (
 				CB984EE6271E25A00034C9BB /* Migration */,
 				CB855ACC27178D31004599EC /* CompletedTestsDefaultsReport.swift */,
+				CB5C294D2732EEC400CEC823 /* SageAuthController.swift */,
 				CB855ACA27178D31004599EC /* SageEarningsController.swift */,
 				CB855ACB27178D31004599EC /* SageScheduleController.swift */,
 				CB855ACD27178D31004599EC /* SageSessionController.swift */,
@@ -1741,6 +1744,7 @@
 				C54AEA6321C81B5F00DEC360 /* CoreDataStack.swift in Sources */,
 				C54AEA1B21C81B5F00DEC360 /* TextAlertView.swift in Sources */,
 				C540B5B1221E0FD000B539A4 /* LanguageViewController.swift in Sources */,
+				CB5C294E2732EEC400CEC823 /* SageAuthController.swift in Sources */,
 				C54AEA1221C81B5F00DEC360 /* FinishedNavigationController.swift in Sources */,
 				CBDC43F3272A8169004ACE2D /* Georgia.swift in Sources */,
 				C54AE9E621C81B5F00DEC360 /* HMRequest.swift in Sources */,

--- a/Arc/App/Utilities/HMRestAPI/Models/ScheduleResponse.swift
+++ b/Arc/App/Utilities/HMRestAPI/Models/ScheduleResponse.swift
@@ -154,8 +154,8 @@ public struct WakeSleepScheduleRequestData : Codable {
 	public var device_info:String // "iOS|iPhone8,4|10.1.1",
 	public var app_version:String // "1.2.4",
 	public var model_version:String // "1",
-    public var timezone_name:String //name of timezone ie "Central Standard Time"
-    public var timezone_offset:String //offset from utc ie "UTC-05:00"
+    public var timezone_name:String? //name of timezone ie "Central Standard Time"
+    public var timezone_offset:String? //offset from utc ie "UTC-05:00"
 	
 	public init(withStudyPeriod studyPeriod: StudyPeriod) {
 		

--- a/Arc/Sage/CompletedTestsDefaultsReport.swift
+++ b/Arc/Sage/CompletedTestsDefaultsReport.swift
@@ -116,6 +116,7 @@ open class CompletedTestsDefaultsReport: UserDefaultsSingletonReport {
             guard let bridgeJsonData = (clientData as? String)?.data(using: .utf8) else {
                 let errorStr = "Error parsing clientData for completed tests report"
                 print(errorStr)
+                completion(errorStr)
                 return
             }
 
@@ -145,9 +146,9 @@ open class CompletedTestsDefaultsReport: UserDefaultsSingletonReport {
                 
                 completion(nil)
             } catch {
-                let errorStr = "Error parsing clientData for completed tests report \(error)"
+                let errorStr = "CompletedTestList invalid data format"
                 completion(errorStr)
-                print(errorStr)
+                print("\(errorStr)\(error.localizedDescription)")
             }
         }
     }

--- a/Arc/Sage/SageAuthController.swift
+++ b/Arc/Sage/SageAuthController.swift
@@ -1,0 +1,173 @@
+//
+//  SageAuthController.swift
+//  Arc
+//
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import BridgeSDK
+
+open class SageAuthController : AuthController {
+    override open func getAuthIssue(from code:Int?) -> String {
+        if let code = code {
+            if code == 401 {
+                return "Invalid  Rater ID or ARC ID".localized("error1")
+            }
+            if code == 409 {
+                return "Already enrolled on another device".localized("error2")
+            }
+        }
+        return "Sorry, our app is currently experiencing issues. Please try again later.".localized("error3")
+    }
+	
+	open override func authenticate(completion: @escaping ((Int64?, String?) -> ())) {
+        
+        guard let password = self.getPassword(),
+              let externalId = self.getUserName(),
+              let arcIdInt = Int64(externalId) else {
+            debugPrint("No user arc id entered")
+            return
+        }
+        
+        // There may be a scenario where we are already signed in,
+        // If that is the guess, then sign out first before moving on.
+        if BridgeSDK.authManager.isAuthenticated() {
+            BridgeSDK.authManager.signOut { task, result, error in
+                // Give BridgeSDK time to clean up
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    self.signIn(arcIdInt: arcIdInt, externalId: externalId, password: password, completion: completion)
+                }
+            }
+            return
+        }
+        
+        self.signIn(arcIdInt: arcIdInt, externalId: externalId, password: password, completion: completion)
+	}
+    
+    fileprivate func signIn(arcIdInt: Int64, externalId: String, password: String, completion: @escaping ((Int64?, String?) -> ())) {
+        BridgeSDK.authManager.signIn(withExternalId: externalId, password: password, completion: { (task, result, error) in
+            
+            guard error == nil else {
+                if ((error?.localizedDescription ?? "").contains("404")) {
+                    completion(nil, "Account not found.")
+                } else {
+                    completion(nil, error?.localizedDescription ?? "Auth sign in error")
+                }
+                return
+            }
+            
+            TaskListScheduleManager.shared.loadHistoryFromBridge { (wakeSleep, testSchedule, error) in
+                if let errorUnwrapped = error {
+                    completion(nil, errorUnwrapped)
+                    return
+                }
+                
+                // Save the ARC ID
+                self.saveArcId(arcIdInt: arcIdInt)
+                
+                // Start with no commitment, unless the two responses below are non-nil
+                Arc.shared.appController.commitment = .none
+                
+                // We need both to consider the user as previously setup
+                guard let wakeSleepUnwrapped = wakeSleep,
+                      let testScheduleUnwrapped = testSchedule else {
+                    completion(arcIdInt, nil)
+                    return
+                }
+                
+                Arc.shared.appController.commitment = .committed
+                Arc.shared.notificationController.authenticateNotifications { (didAuthenticate, error) in
+                    DispatchQueue.main.async {
+                        if self.createTestSessions(schedule: testScheduleUnwrapped) {
+                            Arc.shared.studyController.save()
+                        } else {
+                            print("Error creating sessions from schedule")
+                        }
+                    }
+                }
+                
+                let sortedSessions = testScheduleUnwrapped.sessions.sorted { (test1, test2) -> Bool in
+                    return test1.session_date < test2.session_date
+                }
+                
+                if let firstTest = sortedSessions.first {
+                    Arc.shared.studyController.firstTest = self.convertToTestState(test: firstTest)
+                }
+                
+                // Get the latest test, which is the most recent test we have past
+                let now = Date().timeIntervalSince1970
+                if let latestTest = sortedSessions.filter({ (test) -> Bool in
+                    return now > test.session_date
+                }).last {
+                    Arc.shared.studyController.latestTest = self.convertToTestState(test: latestTest)
+                    Arc.apply(forVersion: "2.0.0")
+                }
+                
+                NotificationCenter.default.post(name: .ACStartEarningsRefresh, object: nil)
+                
+                // Save wake sleep schedule
+                Arc.shared.appController.commitment = .committed
+                MHController.dataContext.performAndWait {
+                    let controller = Arc.shared.scheduleController
+                    for entry in wakeSleepUnwrapped.wake_sleep_data {
+                        let _ = controller.create(entry: entry.wake,
+                                          endTime: entry.bed,
+                                          weekDay: WeekDay.fromString(day: entry.weekday),
+                                          participantId: Int(arcIdInt))
+                    }
+                    controller.save()
+                }
+                
+                completion(arcIdInt, nil)
+            }
+        })
+    }
+    
+    open func createTestSessions(schedule: TestScheduleRequestData) -> Bool {
+        // Needs to be implemented by sub-class
+        assertionFailure("createTestSessions needs to be implemented by sub-class")
+        return false
+    }
+    
+    fileprivate func convertToTestState(test: TestScheduleRequestData.Entry) -> SessionInfoResponse.TestState {
+        return SessionInfoResponse.TestState(session_date: test.session_date, week: Int(test.week), day: Int(test.day), session: Int(test.session), session_id: test.session_id)
+    }
+    
+    fileprivate func saveArcId(arcIdInt: Int64) {
+        // Save the user's Arc ID info
+        MHController.dataContext.perform {
+            let entry:AuthEntry = self.new()
+            entry.authDate = Date()
+            entry.participantID = arcIdInt
+            Arc.shared.participantId = Int(arcIdInt)
+            self.save()
+        }
+    }
+}

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -185,7 +185,15 @@ public class TaskListScheduleManager {
         }
         
         do {
-            let wakeSleep = try jsonDecoder.decode(WakeSleepScheduleRequestData.self, from: data)
+            var wakeSleep = try jsonDecoder.decode(WakeSleepScheduleRequestData.self, from: data)
+            // Fix for cross-compatibility with Android, where thses fields can
+            // sometimes be missing values saved to the server.
+            if (wakeSleep.timezone_name == nil) {
+                wakeSleep.timezone_name = TimeZone.current.description
+            }
+            if (wakeSleep.timezone_offset == nil) {
+                wakeSleep.timezone_offset = (TimeZone.current.secondsFromGMT() / 3600).toString()
+            }
             return wakeSleep
         } catch let error as NSError {
             print("Error while converting client data to WakeSleep format \(error)")

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -148,8 +148,14 @@ public class TaskListScheduleManager {
                 }
                 
                 successCtr -= 1
-                if (successCtr <= 0) {  // Check for done state
+                
+                // Check for done state
+                if (successCtr <= 0 && !completedCalled) {
                     self.forceReloadCompletedTestData { (errorStr) in
+                        if let errorStrUnwrapped = errorStr {
+                            completed(nil, nil, errorStrUnwrapped)
+                            return
+                        }
                         completed(availabilityData, testScheduleData, errorStr)
                     }
                 }


### PR DESCRIPTION
Sarah S signed in with an account that was originally created on Android and had some missing JSON fields required on iOS. It ended up treating the failed JSON parsing as OK and let her restart the study, which cleared out the data on the account. That is not desired, as it should show an error message to the user, keep their data, and then we can fix it on the back-end. This PR accomplishes that.

The original issue with the Android data model is also fixed here.

This PR also moves the file SageAuthController down into the Arc module to make it easier for each app to target the Sage server and share common code.



