### PR TITLE
DIAN-176

### DIFF
--- a/Arc/Components/Auth/Controllers/AuthController.swift
+++ b/Arc/Components/Auth/Controllers/AuthController.swift
@@ -247,4 +247,9 @@ open class AuthController:MHController {
         return "Sorry, our app is currently experiencing issues. Please try again later.".localized(ACTranslationKey.login_error3)
     }
     
+    open func createTestSessions(schedule: TestScheduleRequestData) -> Bool {
+        // Needs to be implemented by sub-class
+        assertionFailure("createTestSessions needs to be implemented by sub-class")
+        return false
+    }
 }

--- a/Arc/CoreDataStack.swift
+++ b/Arc/CoreDataStack.swift
@@ -75,6 +75,7 @@ open class CoreDataStack {
 			
 			container.persistentStoreDescriptions = [description]
 		}
+        var loadingError: NSError? = nil
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
@@ -88,10 +89,23 @@ open class CoreDataStack {
                  * The store could not be migrated to the current model version.
                  Check the error message to determine what the actual problem was.
                  */
-				
-                fatalError("Unresolved error \(error), \(error.userInfo)")
+                
+                loadingError = error
+                //fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })
+        if let error = loadingError {
+            guard let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("arc.sqlite") else {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+            try! persistentContainer.persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: "sqlite", options: nil)
+            
+            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+                if let error = error as NSError? {
+                    fatalError("Unresolved error \(error), \(error.userInfo)")
+                }
+            })
+        }
         return container
     }()
     

--- a/Arc/CoreDataStack.swift
+++ b/Arc/CoreDataStack.swift
@@ -38,7 +38,7 @@ open class CoreDataStack {
     }()
 	public func initializeMockStore() -> NSPersistentContainer {
 		CoreDataStack.useMockContainer = true
-		let container = NSPersistentContainer(name: "arc", managedObjectModel: self.managedObjectModel)
+		let container = NSPersistentContainer(name: "dianarc", managedObjectModel: self.managedObjectModel)
 		let description = NSPersistentStoreDescription()
 		description.type = NSInMemoryStoreType
 		description.shouldAddStoreAsynchronously = false // Make it simpler in test env
@@ -67,7 +67,7 @@ open class CoreDataStack {
          application to it. This property is optional since there are legitimate
          error conditions that could cause the creation of the store to fail.
          */
-		let container = NSPersistentContainer(name: "arc", managedObjectModel: self.managedObjectModel)
+		let container = NSPersistentContainer(name: "dianarc", managedObjectModel: self.managedObjectModel)
 		if let description = container.persistentStoreDescriptions.first {
 		
 			description.shouldInferMappingModelAutomatically = false
@@ -75,7 +75,7 @@ open class CoreDataStack {
 			
 			container.persistentStoreDescriptions = [description]
 		}
-        var loadingError: NSError? = nil
+
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
@@ -89,23 +89,10 @@ open class CoreDataStack {
                  * The store could not be migrated to the current model version.
                  Check the error message to determine what the actual problem was.
                  */
-                
-                loadingError = error
-                //fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        if let error = loadingError {
-            guard let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("arc.sqlite") else {
+
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-            try! persistentContainer.persistentStoreCoordinator.destroyPersistentStore(at: url, ofType: "sqlite", options: nil)
-            
-            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-                if let error = error as NSError? {
-                    fatalError("Unresolved error \(error), \(error.userInfo)")
-                }
-            })
-        }
+        })
         return container
     }()
     

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -554,7 +554,7 @@ public class TaskListScheduleManager: MHController {
     }
     
     public static let migrationDataKey = "migrationDataKey"
-    public static let migrationSteps = 12
+    public static let migrationSteps = 13
 
     public func userNeedsToMigrate(participantId: String?, externalId: String?) -> Bool {
         if (participantId == nil) {
@@ -1010,6 +1010,8 @@ public class TaskListScheduleManager: MHController {
                 
         // We are done with migration!
         DispatchQueue.main.async {
+            progressCtr += 1
+            completionListener.progressUpdate(progress: progressCtr)
             // Remove traces of successful migrations
             self.removeMigrationStateImmediately()
             completionListener.success()

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -187,17 +187,6 @@ public class TaskListScheduleManager: MHController {
                 return
             }
             
-            Arc.shared.appController.commitment = .committed
-            Arc.shared.notificationController.authenticateNotifications { (didAuthenticate, error) in
-                DispatchQueue.main.async {
-                    if Arc.shared.authController.createTestSessions(schedule: testScheduleUnwrapped) {
-                        Arc.shared.studyController.save()
-                    } else {
-                        print("Error creating sessions from schedule")
-                    }
-                }
-            }
-            
             let sortedSessions = testScheduleUnwrapped.sessions.sorted { (test1, test2) -> Bool in
                 return test1.session_date < test2.session_date
             }
@@ -228,6 +217,14 @@ public class TaskListScheduleManager: MHController {
                                       participantId: Int(arcIdInt))
                 }
                 controller.save()
+            }
+            
+            if Arc.shared.authController.createTestSessions(schedule: testScheduleUnwrapped) {
+                Arc.shared.studyController.save()
+            } else {
+                let errorStr = "Error creating sessions from schedule"
+                print(errorStr)
+                completion(nil, errorStr)
             }
             
             completion(arcIdInt, nil)

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -47,7 +47,7 @@ extension RSDIdentifier {
 }
 
 /// Subclass the schedule manager to set up a predicate to filter the schedules.
-public class TaskListScheduleManager {
+public class TaskListScheduleManager: MHController {
     
     public static let shared = TaskListScheduleManager()
     
@@ -82,7 +82,7 @@ public class TaskListScheduleManager {
         return JSONDecoder()
     }()
     
-    var defaults: UserDefaults {
+    var standardDefaults: UserDefaults {
         return UserDefaults.standard
     }
     
@@ -164,6 +164,88 @@ public class TaskListScheduleManager {
                     }
                 }
             }
+        }
+    }
+    
+    open func loadAndSetupUserData(arcIdInt: Int64, completion: @escaping ((Int64?, String?) -> ())) {
+        TaskListScheduleManager.shared.loadHistoryFromBridge { (wakeSleep, testSchedule, error) in
+            if let errorUnwrapped = error {
+                completion(nil, errorUnwrapped)
+                return
+            }
+            
+            // Save the ARC ID
+            self.saveArcId(arcIdInt: arcIdInt)
+            
+            // Start with no commitment, unless the two responses below are non-nil
+            Arc.shared.appController.commitment = .none
+            
+            // We need both to consider the user as previously setup
+            guard let wakeSleepUnwrapped = wakeSleep,
+                  let testScheduleUnwrapped = testSchedule else {
+                completion(arcIdInt, nil)
+                return
+            }
+            
+            Arc.shared.appController.commitment = .committed
+            Arc.shared.notificationController.authenticateNotifications { (didAuthenticate, error) in
+                DispatchQueue.main.async {
+                    if Arc.shared.authController.createTestSessions(schedule: testScheduleUnwrapped) {
+                        Arc.shared.studyController.save()
+                    } else {
+                        print("Error creating sessions from schedule")
+                    }
+                }
+            }
+            
+            let sortedSessions = testScheduleUnwrapped.sessions.sorted { (test1, test2) -> Bool in
+                return test1.session_date < test2.session_date
+            }
+            
+            if let firstTest = sortedSessions.first {
+                Arc.shared.studyController.firstTest = self.convertToTestState(test: firstTest)
+            }
+            
+            // Get the latest test, which is the most recent test we have past
+            let now = Date().timeIntervalSince1970
+            if let latestTest = sortedSessions.filter({ (test) -> Bool in
+                return now > test.session_date
+            }).last {
+                Arc.shared.studyController.latestTest = self.convertToTestState(test: latestTest)
+                Arc.apply(forVersion: "2.0.0")
+            }
+            
+            NotificationCenter.default.post(name: .ACStartEarningsRefresh, object: nil)
+            
+            // Save wake sleep schedule
+            Arc.shared.appController.commitment = .committed
+            MHController.dataContext.performAndWait {
+                let controller = Arc.shared.scheduleController
+                for entry in wakeSleepUnwrapped.wake_sleep_data {
+                    let _ = controller.create(entry: entry.wake,
+                                      endTime: entry.bed,
+                                      weekDay: WeekDay.fromString(day: entry.weekday),
+                                      participantId: Int(arcIdInt))
+                }
+                controller.save()
+            }
+            
+            completion(arcIdInt, nil)
+        }
+    }
+    
+    fileprivate func convertToTestState(test: TestScheduleRequestData.Entry) -> SessionInfoResponse.TestState {
+        return SessionInfoResponse.TestState(session_date: test.session_date, week: Int(test.week), day: Int(test.day), session: Int(test.session), session_id: test.session_id)
+    }
+    
+    fileprivate func saveArcId(arcIdInt: Int64) {
+        // Save the user's Arc ID info
+        MHController.dataContext.perform {
+            let entry:AuthEntry = self.new()
+            entry.authDate = Date()
+            entry.participantID = arcIdInt
+            Arc.shared.participantId = Int(arcIdInt)
+            self.save()
         }
     }
     
@@ -472,7 +554,7 @@ public class TaskListScheduleManager {
     }
     
     public static let migrationDataKey = "migrationDataKey"
-    public static let migrationSteps = 11
+    public static let migrationSteps = 12
 
     public func userNeedsToMigrate(participantId: String?, externalId: String?) -> Bool {
         if (participantId == nil) {
@@ -518,7 +600,6 @@ public class TaskListScheduleManager {
         return nil
     }
     
-    var TODO_REMOVE = 0
     /**
      * @return true if the user needs to migrate from HM to Sage bridge server, false otherwise
      */
@@ -901,6 +982,32 @@ public class TaskListScheduleManager {
             return
         }
         
+        // Wait a second for Bridge server to finish writes
+        progressCtr += 1
+        if (migration.userSynced == nil) {
+            completionListener.progressUpdate(progress: progressCtr)
+            DispatchQueue.main.asyncAfter(deadline: (.now() + 1.0), execute: {
+                let what = "Sync user with bridge data"
+                print(what)
+                guard let arcIdInt = Int64(migration.arcId) else {
+                    self.migrationError(completionListener: completionListener,
+                                        errorStr: "Error \(what) invalid arcIdInt64")
+                    return
+                }
+                self.loadAndSetupUserData(arcIdInt: arcIdInt, completion: { arcIdInt, error in
+                    if let errorStr = error {
+                        self.migrationError(completionListener: completionListener,
+                                            errorStr: "Error \(what) \(errorStr)")
+                        return
+                    }
+                    let newMigration = migration.copy(userSynced: true)
+                    self.saveAndContinueMigration(completionListener: completionListener,
+                                                  newMigration: newMigration)
+                })
+            })
+            return
+        }
+                
         // We are done with migration!
         DispatchQueue.main.async {
             // Remove traces of successful migrations
@@ -918,7 +1025,7 @@ public protocol MigrationCompletedListener: AnyObject {
 
 open class UserDefaultsSingletonReport {
     var defaults: UserDefaults {
-        return TaskListScheduleManager.shared.defaults
+        return TaskListScheduleManager.shared.standardDefaults
     }
     
     var isSyncingWithBridge = false
@@ -967,6 +1074,7 @@ public struct MigrationData: Codable {
     var completedTestUploaded: Bool? = nil
     var sessionScheduleUploaded: Bool? = nil
     var wakeSleepScheduleUploaded: Bool? = nil
+    var userSynced: Bool? = nil
     
     public static func initial(arcId: String, deviceId: String) -> MigrationData {
         return MigrationData(arcId: arcId, deviceId: deviceId)
@@ -984,7 +1092,8 @@ public struct MigrationData: Codable {
                      isNewUserAttributesUpdated: Bool? = nil,
                      completedTestUploaded: Bool? = nil,
                      sessionScheduleUploaded: Bool? = nil,
-                     wakeSleepScheduleUploaded: Bool? = nil) -> MigrationData {
+                     wakeSleepScheduleUploaded: Bool? = nil,
+                     userSynced: Bool? = nil) -> MigrationData {
         
         return MigrationData(
             arcId: self.arcId,
@@ -1001,6 +1110,7 @@ public struct MigrationData: Codable {
             isNewUserAttributesUpdated: isNewUserAttributesUpdated ?? self.isNewUserAttributesUpdated,
             completedTestUploaded: completedTestUploaded ?? self.completedTestUploaded,
             sessionScheduleUploaded: sessionScheduleUploaded ?? self.sessionScheduleUploaded,
-            wakeSleepScheduleUploaded: wakeSleepScheduleUploaded ?? self.wakeSleepScheduleUploaded)
+            wakeSleepScheduleUploaded: wakeSleepScheduleUploaded ?? self.wakeSleepScheduleUploaded,
+            userSynced: userSynced ?? self.userSynced)
     }
 }

--- a/Arc/Sage/TaskListScheduleManager.swift
+++ b/Arc/Sage/TaskListScheduleManager.swift
@@ -551,7 +551,7 @@ public class TaskListScheduleManager: MHController {
     }
     
     public static let migrationDataKey = "migrationDataKey"
-    public static let migrationSteps = 13
+    public static let migrationSteps = 14
 
     public func userNeedsToMigrate(participantId: String?, externalId: String?) -> Bool {
         if (participantId == nil) {


### PR DESCRIPTION
To fix the migration crash, I went ahead and renamed the `NSPersistentContainer` which effectively created a new one that is no longer associated with the old one. iOS will no longer try to migrate it and fail.

I validated this fixes the crash on iOS 12.5 and 15.0, and on both HASD and EXR.

A side effect of this, is we now need to re-initialize the CoreData store with the Availability and TestSessionSchedules after successful migration, as the previous one was deleted.  To do so, I moved the data loading functionality from the `SageAuthController` over to the `TaskListScheduleManager` so that it can be re-used as the last step of migration.