### PR TITLE
DIAN-251

### DIFF
--- a/Arc/App/Controllers/StudyController.swift
+++ b/Arc/App/Controllers/StudyController.swift
@@ -268,8 +268,25 @@ open class StudyController : MHController {
 			}
 		}
 		
-		
-		
+        // There is a data model bug with study period's user start/end date,
+        // So let's try another approach to check for the current study period
+        let nowDate = Date()
+        let fullResults:[StudyPeriod] = fetch(predicate:nil, sort:sortDescriptors) ?? []
+
+        for i in 0..<fullResults.count {
+            let period = fullResults[i]
+            if let sessionUnwrapped = period.sessions {
+                if (sessionUnwrapped.count > 1) {
+                    if let firstSessionDate = (sessionUnwrapped[0] as? Session)?.sessionDate,
+                       let lastSessionDate = (sessionUnwrapped[sessionUnwrapped.count - 1] as? Session)?.sessionDate {
+                        if (nowDate >= firstSessionDate && nowDate <= lastSessionDate) {
+                            return period
+                        }
+                    }
+                }
+            }
+        }
+        
 		return nil;
 	}
 	// Is there a currently running test session?

--- a/Arc/Components/Progress/Viewcontrollers/EarningsViewController.swift
+++ b/Arc/Components/Progress/Viewcontrollers/EarningsViewController.swift
@@ -237,6 +237,9 @@ public class EarningsViewController: CustomViewController<ACEarningsView> {
 	fileprivate func updateBodyText() {
         // There are no syncing of earnings with new local earnings calculations
         customView.lastSyncedLabel.isHidden = true
+
+        // The body label mentions earnings, so only show it if we are doing earnings
+        customView.earningsBodyLabel.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
         
 		customView.bonusGoalsBodyLabel.text = "".localized(ACTranslationKey.earnings_bonus_body)
 		

--- a/Arc/Components/Progress/Viewcontrollers/EarningsViewController.swift
+++ b/Arc/Components/Progress/Viewcontrollers/EarningsViewController.swift
@@ -237,9 +237,6 @@ public class EarningsViewController: CustomViewController<ACEarningsView> {
 	fileprivate func updateBodyText() {
         // There are no syncing of earnings with new local earnings calculations
         customView.lastSyncedLabel.isHidden = true
-
-        // The body label mentions earnings, so only show it if we are doing earnings
-        customView.earningsBodyLabel.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
         
 		customView.bonusGoalsBodyLabel.text = "".localized(ACTranslationKey.earnings_bonus_body)
 		
@@ -254,6 +251,12 @@ public class EarningsViewController: CustomViewController<ACEarningsView> {
 			
 			break
 		}
+        
+        // The body label mentions earnings, so only show it if we are doing earnings
+        customView.earningsBodyLabel.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
+        if (!ACHomeTabViewController.shouldShowEarningsTab) {
+            customView.earningsBodyLabel.text = ""
+        }
 	}
 	fileprivate func setGoalRewardText(value:String, goalView:GoalView, isComplete:Bool, date:TimeInterval?) {
 		

--- a/Arc/Components/Progress/Viewcontrollers/ProgressViewController.swift
+++ b/Arc/Components/Progress/Viewcontrollers/ProgressViewController.swift
@@ -45,6 +45,7 @@ class ProgressViewController: CustomViewController<ACProgressView> {
 		thisStudyProgressSetup()
 		self.navigationController?.isNavigationBarHidden = true
 
+        customView.viewFaqButton.titleLabel?.textAlignment = .center
 		customView.viewFaqButton.addTarget(self, action: #selector(self.viewFaqPressed), for: .touchUpInside)
     }
     

--- a/Arc/Components/Progress/Viewcontrollers/ProgressViewController.swift
+++ b/Arc/Components/Progress/Viewcontrollers/ProgressViewController.swift
@@ -107,6 +107,7 @@ class ProgressViewController: CustomViewController<ACProgressView> {
 			customView.noticeLabel.text = "Thanks for completing the practice session today! *Your testing week officially begins tomorrow.*".localized(ACTranslationKey.progress_baseline_notice)
 			if let today = todaysProgress, today.sessionsCompleted == 0 {
 				customView.noticeLabel.text = "".localized(ACTranslationKey.progress_practice_body2)
+                customView.noticeLabel.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
                 if ACHomeTabViewController.shouldShowEarningsTab {
                     customView.noticeLabel.text = nil // Do not say anything about earnings
                 }

--- a/Arc/Components/Progress/views/ACTodayProgressView.swift
+++ b/Arc/Components/Progress/views/ACTodayProgressView.swift
@@ -146,6 +146,7 @@ public class ACTodayProgressView : UIView {
                 
                 Roboto.Style.body($0, color: ACColor.secondaryText)
                 $0.text = "progress_practice_body2"
+                $0.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
                 
                 if ACHomeTabViewController.shouldShowEarningsTab {
                     $0.text = nil // Do not say anything about earnings

--- a/Arc/Components/Progress/views/ACTodayProgressView.swift
+++ b/Arc/Components/Progress/views/ACTodayProgressView.swift
@@ -146,10 +146,9 @@ public class ACTodayProgressView : UIView {
                 
                 Roboto.Style.body($0, color: ACColor.secondaryText)
                 $0.text = "progress_practice_body2"
-                $0.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
                 
-                if ACHomeTabViewController.shouldShowEarningsTab {
-                    $0.text = nil // Do not say anything about earnings
+                if !ACHomeTabViewController.shouldShowEarningsTab {
+                    $0.text = "" // Do not say anything about earnings
                 }
                 
                 //$0.font = UIFont(name: "Roboto", size: 17)
@@ -162,8 +161,11 @@ public class ACTodayProgressView : UIView {
                     $0.bottom == safeAreaLayoutGuide.bottomAnchor - 100
                 }
                 
-                $0.fadeIn(animationParams)
-                    .translate(animationParams)
+                $0.isHidden = !ACHomeTabViewController.shouldShowEarningsTab
+                if (ACHomeTabViewController.shouldShowEarningsTab) {
+                    $0.fadeIn(animationParams)
+                        .translate(animationParams)
+                }
             }
         }
 		


### PR DESCRIPTION
Some users were getting notifications at the correct time to do their tests, but when they would enter the app, the home screen would say they didn't have any tests to do.

I tracked the issue down for a few participants to be the app not able to find the current study period correctly.  This was because the userStartDate and userEndDate of the CoreData model for StudyPeriods was incorrect.  

As a backup, I look through earliest and latest session of a study period and use that date range instead. This retroactively fixed the issue for the participants.

